### PR TITLE
reduce edges considered for undirected edges

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,8 @@ impl Graph {
             // directed and then undirected next.
             // TODO: avoid iteration of j and k by using a stack to track candidates??
             let mut used_unconnected_j_vertex = false;
+            // directed edges can connect to previously seen vertices, unseen but connected vertices, or a single new
+            // unconnected vertex.
             for j in 1..n + 2 {
                 // directed edge
                 if i == j {
@@ -188,7 +190,9 @@ impl Graph {
 
                     if g.vertices[i_][2].is_none() {
                         let mut used_unconnected_k_vertex = false;
-                        for k in 1..n + 2 {
+                        // undirected edges can only connect to unseen but connected vertices or single new unconnected
+                        // vertex.
+                        for k in i + 1..n + 2 {
                             // undirected edge
                             if i == k {
                                 continue;


### PR DESCRIPTION
undirected edges can only connect to unseen but connected vertices
or single new unconnected vertex

```
case	n	result	dur_ms	dur_pretty
F(2)	2	1	0	14.20µs
F(4)	4	5	0	25.81µs
F(6)	6	35	0	139.61µs
F(8)	8	319	1	1.73ms
F(10)	10	3559	12	12.81ms
F(12)	12	46841	163	163.48ms
F(14)	14	709601	2220	2.22s


F(16)	16	12156445	38673	38.67s
```