### PR TITLE
improve iteration of edge candidate vertices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple generator of "Feynman diagram" permutations (as defined by [problem 781](https://projecteuler.net/problem=781)). Incrementally builds isomorphically unique graphs in a compact adjacency representation using backtracking at over 13M results a second on my 2020 Macbook.
 
-Implemented quickly to play around with performance improvements, graph traversals, and to try out Rust for the first time. 🦀
+Implemented quickly to play around with program optimizations, graph traversals, and to try out Rust for the first time. 🦀
 
 ### Problem 781?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Feynman diagram generator ⚛️
 
-A simple generator of "Feynman diagram" permutations (as defined by [problem 781](https://projecteuler.net/problem=781)). Incrementally builds candidate graphs in a compact adjacency representation with backtracking and no isomorphic duplicates.
+A simple generator of "Feynman diagram" permutations (as defined by [problem 781](https://projecteuler.net/problem=781)). Incrementally builds isomorphically unique graphs in a compact adjacency representation using backtracking at over 13M results a second on my 2020 Macbook.
 
 Implemented quickly to play around with performance improvements, graph traversals, and to try out Rust for the first time. 🦀
 
@@ -8,7 +8,7 @@ Implemented quickly to play around with performance improvements, graph traversa
 
 This is NOT a solution for the problem whose math is left as an exercise for the reader. Good luck.
 
-This does not leverage any simplification needed to directly calculate the goal F(50000), but actually generates graph permutation and counts them (over 12M a second). This is clearly not scalable, but is fun! I was, at the time, interested in tiny chess engines and there is a similar underlying problem of rapidly generating states. The enumeration and visualization of small N graphs sparked ideas for the solution, but let's keep those to ourselves 🤫.
+This does not leverage any simplification needed to directly calculate the goal F(50000), but actually generates graph permutation and counts them. This is clearly not scalable, but is fun! I was, at the time, interested in tiny chess engines and there is a similar underlying problem of rapidly generating states. The enumeration and visualization of small N graphs sparked ideas for the solution, but let's keep those to ourselves. 🤫
 
 > Let F(n) be the number of connected graphs with blue edges (directed) and red edges (undirected) containing:
 > * two vertices of degree 1, one with a single outgoing blue edge and the other with a single incoming blue edge.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Implemented quickly to play around with performance improvements, graph traversa
 
 This is NOT a solution for the problem whose math is left as an exercise for the reader. Good luck.
 
-This does not leverage any simplification needed to directly calculate the goal F(50000), but actually generates graph permutation and counts them (over 9M a second). This is clearly not scalable, but is fun! I was, at the time, interested in tiny chess engines and there is a similar underlying problem of rapidly generating states. The enumeration and visualization of small N graphs sparked ideas for the solution, but let's keep those to ourselves 🤫.
+This does not leverage any simplification needed to directly calculate the goal F(50000), but actually generates graph permutation and counts them (over 12M a second). This is clearly not scalable, but is fun! I was, at the time, interested in tiny chess engines and there is a similar underlying problem of rapidly generating states. The enumeration and visualization of small N graphs sparked ideas for the solution, but let's keep those to ourselves 🤫.
 
 > Let F(n) be the number of connected graphs with blue edges (directed) and red edges (undirected) containing:
 > * two vertices of degree 1, one with a single outgoing blue edge and the other with a single incoming blue edge.


### PR DESCRIPTION
track j_0 and k_0 cursors to the first vertices we need to consider for the directed and undirected edges.

now well under arbitrary goal of 1s for N=16 or 12.2M edges! done with all of the initial performance TODOs i had.

```
case	n	result	dur_ms	dur_pretty
F(2)	2	1	0	587.00ns
F(4)	4	5	0	1.55µs
F(6)	6	35	0	6.34µs
F(8)	8	319	0	37.51µs
F(10)	10	3559	0	314.48µs
F(12)	12	46841	3	3.91ms
F(14)	14	709601	52	52.95ms
F(16)	16	12156445	899	899.53ms
```