### PR TITLE
Clean up Rust best practices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -Dwarnings
       - name: Build and run main.rs
         run: make run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
+          args: --check
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,12 @@ lto = true
 codegen-units = 1
 panic = "abort"
 
+[features]
+debug = []
+debug-graphviz = []
+print-solutions = []
+print-solutions-graphviz = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 run:
-	(cd src; rustc -O -C target-cpu=native main.rs; ./main; rm main)
+	RUSTFLAGS="-C target-cpu=native" cargo run -q --release
 
 clean: # rm leftover binary if make run is interrupted
 	rm src/main

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -13,11 +13,7 @@ use std::fmt::Write;
 // a performance and memory overhead for small N but allows us to get sequential memory allocation.
 const MAX_N: usize = 16;
 
-// These flags control printing debug information.
-const DEBUG: bool = false;
-const DEBUG_GRAPHVIZ: bool = false;
-const PRINT_SOLUTIONS: bool = false;
-const PRINT_SOLUTIONS_GRAPHVIZ: bool = false;
+// Print debugging information via Cargo features. See Cargo.toml.
 
 #[derive(Default, Clone)]
 pub struct Graph {
@@ -59,18 +55,18 @@ impl Graph {
         mut j_0: usize,
         mut k_0: usize,
     ) {
-        if DEBUG {
+        if cfg!(feature = "debug") {
             println!("PROCESSING i={}, n={}:\t\t\t\t{:?}", i, n, g.vertices);
-            if DEBUG_GRAPHVIZ {
+            if cfg!(feature = "debug-graphviz") {
                 println!("{}", g.to_graphviz());
             }
         }
 
         if i == n + 2 {
             // end reached.
-            if PRINT_SOLUTIONS {
+            if cfg!(feature = "print-solutions") {
                 println!("solution found:\t{:?}", g.vertices);
-                if PRINT_SOLUTIONS_GRAPHVIZ {
+                if cfg!(feature = "print-solutions-graphviz") {
                     println!("{}", g.to_graphviz());
                 }
             }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
  */
 
 // This defines the size of the underlying vertex array. Raise this limit to call generate(n) with larger n. This incurs
-// a performance and memory penalty for small N but allows us to get sequential memory allocation.
+// a performance and memory overhead for small N but allows us to get sequential memory allocation.
 const MAX_N: usize = 16;
 
 // These flags control printing debug information.
@@ -31,7 +31,7 @@ impl Graph {
         if n % 2 == 1 {
             return 0;
         }
-        if n as usize > MAX_N {
+        if usize::from(n) > MAX_N {
             panic!(
                 "n ({}) cannot be greater than configured MAX_N ({})",
                 n, MAX_N
@@ -50,7 +50,6 @@ impl Graph {
     // used_sink tracks if we have already treated a prior vertex as the sink
     // j_0 is a cursor tracking the first vertex we need to consider for the directed edge
     // k_0 is a cursor tracking the first vertex we need to consider for the undirected edge
-    //
     // NOTE: j and k iteration could be optimized further but this is nice and simple
     fn _generate(
         n: u16,
@@ -79,7 +78,7 @@ impl Graph {
             *count += 1;
             return;
         }
-        let i_: usize = i as usize;
+        let i_: usize = usize::from(i);
 
         if i == 0 {
             // source vertex. place a single outgoing edge.
@@ -106,7 +105,7 @@ impl Graph {
                 if i == j {
                     continue;
                 }
-                let j_: usize = j as usize;
+                let j_: usize = usize::from(j);
 
                 if g.vertices[j_][1].is_some() {
                     // scoot the j_0 cursor over
@@ -126,14 +125,14 @@ impl Graph {
                 if g.vertices[i_][2].is_none() {
                     let mut used_unconnected_k_vertex = false;
                     // start from the greater of the k_0 cursor or the next vertex
-                    if (i as usize) + 1 > k_0 {
-                        k_0 = (i as usize) + 1
+                    if i_ + 1 > k_0 {
+                        k_0 = i_ + 1
                     }
                     for k in (k_0 as u16)..n + 2 {
                         if i == k {
                             continue;
                         }
-                        let k_: usize = k as usize;
+                        let k_: usize = usize::from(k);
 
                         if g.vertices[k_][2].is_some() {
                             // scoot the k_0 cursor over
@@ -199,7 +198,7 @@ impl Graph {
             if v[0].is_some() {
                 _ = write!(str, "\n\t{} -> {};", i, v[0].unwrap());
             }
-            if v[2].is_some() && v[2].unwrap() as usize > i {
+            if matches!(v[2], Some(x) if usize::from(x) > i) {
                 _ = write!(str, "\n\t{} -> {} [dir=none, color=red];", i, v[2].unwrap());
             }
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -19,6 +19,7 @@ const DEBUG_GRAPHVIZ: bool = false;
 const PRINT_SOLUTIONS: bool = false;
 const PRINT_SOLUTIONS_GRAPHVIZ: bool = false;
 
+#[derive(Default, Clone)]
 pub struct Graph {
     // index represents vertex id
     // values are a tuple of (directed edge to, directed edge from, undirected edge to) vertex ids
@@ -37,9 +38,7 @@ impl Graph {
                 n, MAX_N
             );
         }
-        let mut g = Graph {
-            vertices: [[None; 3]; MAX_N + 2],
-        };
+        let mut g = Graph::default();
         let mut count: u64 = 0;
         Self::_generate(n, &mut g, &mut count, 0, false, 2, 2);
         count

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ fn timed_header() {
 // prints a csv line for timed run
 fn timed_generate<F>(func: F, n: u16)
 where
-    F: Fn(u16) -> u64,
+    F: FnOnce(u16) -> u64,
 {
     use std::time::Instant;
     let now = Instant::now();
@@ -27,13 +27,7 @@ where
 fn main() {
     // generation
     timed_header();
-    timed_generate(graph::Graph::generate, 0);
-    timed_generate(graph::Graph::generate, 2);
-    timed_generate(graph::Graph::generate, 4);
-    timed_generate(graph::Graph::generate, 6);
-    timed_generate(graph::Graph::generate, 8);
-    timed_generate(graph::Graph::generate, 10);
-    timed_generate(graph::Graph::generate, 12);
-    timed_generate(graph::Graph::generate, 14);
-    timed_generate(graph::Graph::generate, 16);
+    for x in (0..17).step_by(2) {
+        timed_generate(graph::Graph::generate, x);
+    }
 }


### PR DESCRIPTION
clean up rust bread and butter. h/t lopopolo

* run using cargo
* safe conversion to usize. do not repeat the generate calls
* derive Default and Clone traits on Graph
* control debug printing via Cargo features
* run cargo fmt with check flag in CI
* run cargo clippy to fail on warnings in CI